### PR TITLE
fix: Use lowercase font metadata sidecars

### DIFF
--- a/scripts/generate-font-metadata.py
+++ b/scripts/generate-font-metadata.py
@@ -289,7 +289,7 @@ class SbmuflFont(object):
         font_dir = os.path.dirname(os.path.abspath(self.filepath))
         extra_filename = os.path.join(
             font_dir,
-            f"{self.font.fontname}.extra.json",
+            f"{self.font.fontname.lower()}.extra.json",
         )
         if os.path.exists(extra_filename):
             with open(extra_filename, "r", encoding="utf-8") as infile:


### PR DESCRIPTION
The metadata files and extra sidecars are lowercase in the generated assets, matching the canonical naming in Neanes. The font names themselves remain CamelCase, so using FontName directly made Linux case-sensitive builds miss the extra defaults while case-insensitive macOS builds still found them. Lowercase the sidecar lookup so build output is consistent across case-sensitive and case-insensitive filesystems.